### PR TITLE
Making some changes to match the facebook flux example

### DIFF
--- a/src/scripts/actions/SideBarNavActionCreators.js
+++ b/src/scripts/actions/SideBarNavActionCreators.js
@@ -7,19 +7,18 @@ let ActionTypes = Constants.ActionTypes;
 
 module.exports = {
 
-  getPages(query) {
+  clickNavNode(lineage) {
     AppDispatcher.handleViewAction({
-      type: ActionTypes.LOAD_PAGES,
-      query: query
+      type: ActionTypes.CLICK_NAVIGATION_NODE,
+      lineage: lineage
     });
-    WebAPIUtils.loadPages(query);
   },
 
-  getNavigationMenu() {
-  	AppDispatcher.handleViewAction({
-  	  type: ActionTypes.LOAD_NAVIGATION_MENU
-  	});
-  	WebAPIUtils.loadNavigationMenu();
+  clickNavExpandCollapse(lineage) {
+    AppDispatcher.handleViewAction({
+      type: ActionTypes.CLICK_NAVIGATION_EXPAND_COLLAPSE,
+      lineage: lineage
+    });
   },
 
   updateSearchString(searchString) {

--- a/src/scripts/constants/Constants.js
+++ b/src/scripts/constants/Constants.js
@@ -32,7 +32,7 @@ module.exports = {
     // RECEIVE_STORY: null,
     // CREATE_STORY: null,
     // RECEIVE_CREATED_STORY: null
-   
+
 
     // Pages
     RECEIVE_PAGES: null,
@@ -41,6 +41,8 @@ module.exports = {
     // Nav menu
     RECEIVE_NAVIGATION_MENU_JSON: null,
     LOAD_NAVIGATION_MENU: null,
+    CLICK_NAVIGATION_NODE: null,
+    CLICK_NAVIGATION_EXPAND_COLLAPSE: null,
 
     // Search
     UPDATE_SEARCH_STRING: null,

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -8,7 +8,10 @@ import { history } from 'react-router/lib/BrowserHistory';
 
 const React = require('react'),
 			SideBarNav = require('./components/SideBarNav.jsx'),
-			Content = require('./components/Content');
+			Content = require('./components/Content'),
+      WebAPIUtils = require('./utils/WebAPIUtils');
+
+WebAPIUtils.loadNavigationMenu();
 
 var App = React.createClass({
 

--- a/src/scripts/stores/SideBarNavStore.js
+++ b/src/scripts/stores/SideBarNavStore.js
@@ -12,9 +12,10 @@ let EventEmitter = require('events').EventEmitter,
 let _pages = [];
 let _navigationMenu = [{title: 'Loading...'}];
 let _searchString = '';
+let _selectedLineage = [];
+let _collapsedNodeKeys = {};
 
 let SideBarNavStore = assign({}, EventEmitter.prototype, {
-
 
 	emitChange() {
 		this.emit('change');
@@ -40,11 +41,35 @@ let SideBarNavStore = assign({}, EventEmitter.prototype, {
 		return _searchString;
 	},
 
+  getSelectedLineage() {
+    return _selectedLineage;
+  },
+
+  getCollapsedNodeLineages() {
+    return _.keys(_collapsedNodeKeys).map(key => {
+      return key.split('__')
+    });
+  }
+
 });
 
 SideBarNavStore.dispatchToken = AppDispatcher.register(function(payload) {
 	let action = payload.action;
 	switch(action.type) {
+
+    case ActionTypes.CLICK_NAVIGATION_NODE:
+      _selectedLineage = action.lineage;
+      SideBarNavStore.emitChange();
+      break;
+
+    case ActionTypes.CLICK_NAVIGATION_EXPAND_COLLAPSE:
+      let key = action.lineage.join('__');
+      _collapsedNodeKeys[key] = !_collapsedNodeKeys[key];
+      if (!_collapsedNodeKeys[key]) {
+        delete _collapsedNodeKeys[key];
+      }
+      SideBarNavStore.emitChange();
+      break;
 
 		case ActionTypes.RECEIVE_PAGES_ARRAY:
       _pages = action.pagesArray;

--- a/src/scripts/utils/WebAPIUtils.js
+++ b/src/scripts/utils/WebAPIUtils.js
@@ -9,23 +9,23 @@ module.exports = {
 
 	loadNavigationMenu() {
 
-		// setTimeout(() => {
-		// 	var navMenuText = '[{"ID":46,"order":1,"parent":0,"title":"Home","url":"http:\/\/mobilestyle.ups.dev\/home\/","attr":"","target":"","classes":"","xfn":"","description":"","object_id":2,"object":"page","type":"post_type","type_label":"Page","children":[{"ID":47,"order":2,"parent":46,"title":"Getting Started","url":"http:\/\/mobilestyle.ups.dev\/home\/getting-started\/","attr":"","target":"","classes":"","xfn":"","description":"","object_id":15,"object":"page","type":"post_type","type_label":"Page","children":[]},{"ID":48,"order":3,"parent":46,"title":"Interaction Design Principles","url":"http:\/\/mobilestyle.ups.dev\/home\/interaction-design-principles\/","attr":"","target":"","classes":"","xfn":"","description":"","object_id":22,"object":"page","type":"post_type","type_label":"Page","children":[{"ID":49,"order":4,"parent":48,"title":"Design Principle the First","url":"http:\/\/mobilestyle.ups.dev\/home\/interaction-design-principles\/design-principle-the-first\/","attr":"","target":"","classes":"","xfn":"","description":"","object_id":24,"object":"page","type":"post_type","type_label":"Page","children":[]}]}]},{"ID":54,"order":5,"parent":0,"title":"UPS Mobile (iOS, Android)","url":"http:\/\/mobilestyle.ups.dev\/ups-mobile\/","attr":"","target":"","classes":"","xfn":"","description":"","object_id":13,"object":"page","type":"post_type","type_label":"Page","children":[{"ID":55,"order":6,"parent":54,"title":"Overview","url":"http:\/\/mobilestyle.ups.dev\/ups-mobile\/overview\/","attr":"","target":"","classes":"","xfn":"","description":"","object_id":26,"object":"page","type":"post_type","type_label":"Page","children":[]},{"ID":56,"order":7,"parent":54,"title":"Reference","url":"http:\/\/mobilestyle.ups.dev\/ups-mobile\/reference\/","attr":"","target":"","classes":"","xfn":"","description":"","object_id":28,"object":"page","type":"post_type","type_label":"Page","children":[]}]},{"ID":50,"order":8,"parent":0,"title":"mDot","url":"http:\/\/mobilestyle.ups.dev\/mdot\/","attr":"","target":"","classes":"","xfn":"","description":"","object_id":8,"object":"page","type":"post_type","type_label":"Page","children":[{"ID":51,"order":9,"parent":50,"title":"Elements","url":"http:\/\/mobilestyle.ups.dev\/mdot\/elements\/","attr":"","target":"","classes":"","xfn":"","description":"","object_id":30,"object":"page","type":"post_type","type_label":"Page","children":[{"ID":52,"order":10,"parent":51,"title":"Navigation","url":"http:\/\/mobilestyle.ups.dev\/mdot\/elements\/navigation\/","attr":"","target":"","classes":"","xfn":"","description":"","object_id":32,"object":"page","type":"post_type","type_label":"Page","children":[]}]}]}]';
-		// 	ServerActionCreators.receiveNavigationMenuJSON(JSON.parse(navMenuText));
-		// });
+		setTimeout(() => {
+			var navMenuText = '[{"ID":46,"order":1,"parent":0,"title":"Home","url":"http:\/\/mobilestyle.ups.dev\/home\/","attr":"","target":"","classes":"","xfn":"","description":"","object_id":2,"object":"page","type":"post_type","type_label":"Page","children":[{"ID":47,"order":2,"parent":46,"title":"Getting Started","url":"http:\/\/mobilestyle.ups.dev\/home\/getting-started\/","attr":"","target":"","classes":"","xfn":"","description":"","object_id":15,"object":"page","type":"post_type","type_label":"Page","children":[]},{"ID":48,"order":3,"parent":46,"title":"Interaction Design Principles","url":"http:\/\/mobilestyle.ups.dev\/home\/interaction-design-principles\/","attr":"","target":"","classes":"","xfn":"","description":"","object_id":22,"object":"page","type":"post_type","type_label":"Page","children":[{"ID":49,"order":4,"parent":48,"title":"Design Principle the First","url":"http:\/\/mobilestyle.ups.dev\/home\/interaction-design-principles\/design-principle-the-first\/","attr":"","target":"","classes":"","xfn":"","description":"","object_id":24,"object":"page","type":"post_type","type_label":"Page","children":[]}]}]},{"ID":54,"order":5,"parent":0,"title":"UPS Mobile (iOS, Android)","url":"http:\/\/mobilestyle.ups.dev\/ups-mobile\/","attr":"","target":"","classes":"","xfn":"","description":"","object_id":13,"object":"page","type":"post_type","type_label":"Page","children":[{"ID":55,"order":6,"parent":54,"title":"Overview","url":"http:\/\/mobilestyle.ups.dev\/ups-mobile\/overview\/","attr":"","target":"","classes":"","xfn":"","description":"","object_id":26,"object":"page","type":"post_type","type_label":"Page","children":[]},{"ID":56,"order":7,"parent":54,"title":"Reference","url":"http:\/\/mobilestyle.ups.dev\/ups-mobile\/reference\/","attr":"","target":"","classes":"","xfn":"","description":"","object_id":28,"object":"page","type":"post_type","type_label":"Page","children":[]}]},{"ID":50,"order":8,"parent":0,"title":"mDot","url":"http:\/\/mobilestyle.ups.dev\/mdot\/","attr":"","target":"","classes":"","xfn":"","description":"","object_id":8,"object":"page","type":"post_type","type_label":"Page","children":[{"ID":51,"order":9,"parent":50,"title":"Elements","url":"http:\/\/mobilestyle.ups.dev\/mdot\/elements\/","attr":"","target":"","classes":"","xfn":"","description":"","object_id":30,"object":"page","type":"post_type","type_label":"Page","children":[{"ID":52,"order":10,"parent":51,"title":"Navigation","url":"http:\/\/mobilestyle.ups.dev\/mdot\/elements\/navigation\/","attr":"","target":"","classes":"","xfn":"","description":"","object_id":32,"object":"page","type":"post_type","type_label":"Page","children":[]}]}]}]';
+			ServerActionCreators.receiveNavigationMenuJSON(JSON.parse(navMenuText));
+		});
 
-		request('GET', APIEndpoints.WP_JSON + APIEndpoints.WP_MAIN_NAV_MENU)
-		  .set('Accept', 'application/json')
-		  .end()
-		  .then(function onResult(res) {
-		    // do stuff
-		    let json = JSON.parse(res.text);
-		    ServerActionCreators.receiveNavigationMenuJSON(json);
-		  })
-		  .catch(function(error) {
-		    // handle errors
-		    console.log(error);
-		  });
+		// request('GET', APIEndpoints.WP_JSON + APIEndpoints.WP_MAIN_NAV_MENU)
+		//   .set('Accept', 'application/json')
+		//   .end()
+		//   .then(function onResult(res) {
+		//     // do stuff
+		//     let json = JSON.parse(res.text);
+		//     ServerActionCreators.receiveNavigationMenuJSON(json);
+		//   })
+		//   .catch(function(error) {
+		//     // handle errors
+		//     console.log(error);
+		//   });
 	},
 
 	loadPages(searchString) {


### PR DESCRIPTION
https://github.com/facebook/flux/tree/master/examples/flux-chat

The main 2 things are:
1. Moving the server fetch to be the first thing to happen in `main.js` (fb app calls this file `app.js`)
2. Nav click events now trigger Actions.  The store receives those and maintains the state.

So the SideBarNav simply draws itself based on the state of the store and triggers Actions.

cc: @Iawhite76 
